### PR TITLE
Add registrar specific links

### DIFF
--- a/services/private_domains/private_domains.rst
+++ b/services/private_domains/private_domains.rst
@@ -113,6 +113,19 @@ your domain.
       :width: 600px
       :align: center
 
+  =============== ==================
+  DNS Provider    Documentation Link
+  =============== ==================
+  Amazon Route 53 `Creating Records Using the Amazon Route 53 Console <https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-creating.html>`_
+  GoDaddy         `Adding an MX record <https://www.godaddy.com/help/add-an-mx-record-19234>`_
+  Dreamhost       `How do I change my MX records <https://help.dreamhost.com/hc/en-us/articles/215035328-How-do-I-change-my-MX-records->`_
+  Cloudflare      `Managing DNS records in CloudFlare <https://support.cloudflare.com/hc/en-us/articles/360019093151>`_
+  HostGator       `How to Setup Your MX Record <https://www.hostgator.com/help/article/mail-exchange-record-what-to-put-for-your-mx-record>`_
+  Namecheap       `How can I setup mx records <https://www.namecheap.com/support/knowledgebase/article.aspx/322/2237/how-can-i-set-up-mx-records-required-for-mail-service>`_
+  Names.co.uk     `Changing your domain's DNS settings <https://www.names.co.uk/support/1156-changing_your_domains_dns_settings.html>`_
+  Wix             `Adding or updating MX Records in Your Wix account <https://support.wix.com/en/article/adding-or-updating-mx-records-in-your-wix-account>`_
+  =============== ==================
+
 #. Verify DNS Settings
 
    Click the "Query My DNS Settings Now" button to verify your DNS settings.

--- a/services/private_domains/private_domains.rst
+++ b/services/private_domains/private_domains.rst
@@ -69,6 +69,19 @@ your domain.
       DNS (`Namecheap <https://www.namecheap.com/support/knowledgebase/article.aspx/317/2237/how-do-i-add-txtspfdkimdmarc-records-for-my-domain>`_
       , `Godaddy Documentation <https://www.godaddy.com/help/add-a-txt-record-19232>`_).
 
+  =============== ==================
+  DNS Provider    Documentation Link
+  =============== ==================
+  Amazon Route 53 `Creating Records Using the Amazon Route 53 Console <https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-creating.html>`_
+  GoDaddy         `Add a TXT record <https://www.godaddy.com/help/add-a-txt-record-19232>`_
+  Dreamhost       `How do I add custom DNS records <https://help.dreamhost.com/hc/en-us/articles/215414867-How-do-I-add-custom-DNS-records->`_
+  Cloudflare      `Managing DNS records in CloudFlare <https://support.cloudflare.com/hc/en-us/articles/360019093151>`_
+  HostGator       `Manage DNS records <https://www.hostgator.com/help/article/manage-dns-records-with-hostgatorenom>`_
+  Namecheap       `How do I add TXT/SPF/DKIM/DMARC records for my domain <https://www.namecheap.com/support/knowledgebase/article.aspx/317/2237/how-do-i-add-txtspfdkimdmarc-records-for-my-domain>`_
+  Names.co.uk     `Changing your domain's DNS settings <https://www.names.co.uk/support/1156-changing_your_domains_dns_settings.html>`_
+  Wix             `Adding or updating TXT Records in Your Wix account <https://support.wix.com/en/article/adding-or-updating-txt-records-in-your-wix-account>`_
+  =============== ==================
+
 #. Configure TXT DNS record for SPF
 
    Create a TXT record for SPF with the hostname and value found on the DNS

--- a/services/private_domains/private_domains.rst
+++ b/services/private_domains/private_domains.rst
@@ -78,6 +78,19 @@ your domain.
       :width: 600px
       :align: center
 
+  =============== ==================
+  DNS Provider    Documentation Link
+  =============== ==================
+  Amazon Route 53 `Creating Records Using the Amazon Route 53 Console <https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-creating.html>`_
+  GoDaddy         `Adding an SPF record <https://www.godaddy.com/help/add-an-spf-record-19218>`_
+  Dreamhost       `How do I add an SPF record <https://help.dreamhost.com/hc/en-us/articles/216106197-How-do-I-add-an-SPF-record->`_
+  Cloudflare      `Managing DNS records in CloudFlare <https://support.cloudflare.com/hc/en-us/articles/360019093151>`_
+  HostGator       `SPF Records <https://www.hostgator.com/help/article/spf-records>`_
+  Namecheap       `How do I add TXT/SPF/DKIM/DMARC records for my domain <https://www.namecheap.com/support/knowledgebase/article.aspx/317/2237/how-do-i-add-txtspfdkimdmarc-records-for-my-domain>`_
+  Names.co.uk     `Changing your domain's DNS settings <https://www.names.co.uk/support/1156-changing_your_domains_dns_settings.html>`_
+  Wix             `Adding or updating SPF Records in Your Wix account <https://support.wix.com/en/article/adding-or-updating-spf-records-in-your-wix-account>`_
+  =============== ==================
+
 #. Configure MX records to receive mail
 
    Create two MX records to receive mail with the hostname and value found on

--- a/services/private_domains/private_domains.rst
+++ b/services/private_domains/private_domains.rst
@@ -17,7 +17,7 @@ BYODomain (Bring Your Own Domain) allows you to easily receive email with a
 domain or subdomain you already own. If you do not already own a domain you can
 use our Zero-Setup Subdomain. Alternatively, you can purchase a domain from a
 registrar (`Namecheap <https://namecheap.com>`_ or
-`GoDaddy <https://godaddy.com>`_) and configure it for Mailsac.
+`GoDaddy <https://godaddy.com>`_) and configure it for use with Mailsac.
 
 BYODomain Configuration
 =======================
@@ -55,7 +55,7 @@ your domain.
 
 #. Configure TXT DNS record for DKIM
 
-   Create a TXT record for DKIM with the hostname and value found on the DN
+   Create a TXT record for DKIM with the hostname and value found on the DNS
    Setup page
    in the Mailsac dashboard.
 


### PR DESCRIPTION
This adds registrar specific links for configuring MX, DKIM (TXT), and SPF (TXT) records.

Fixes ruffrey/mailsac-private#363

Changes can be view on RTD https://docs.mailsac.com/en/add_registrar_specific_links/services/private_domains/private_domains.html

![image](https://user-images.githubusercontent.com/5890769/71992416-359fe100-31ea-11ea-96be-8699d4300a34.png)
