### PR TITLE
Grammer edits and spelling

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -100,7 +100,9 @@ Nope. Only you can see them when you are logged in.
 How do I reply to my Mailsac emails?
 ------------------------------------
 
-You must `create an account <https://mailsac.com/register>`_ to reply to emails. You'll get a few to start out, then can buy more as needed.
+You must `create an account <https://mailsac.com/register>`_ to reply to
+emails. New accounts have 5 sending credits. Additional credits can be
+`purchased <https://mailsac.com/pricing>_`.
 
 Or, you can use `POP3 <https://mailsac.com/docs/fetch-messages-with-pop3>`_ to download
 messages on a private address or custom domain.

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -83,7 +83,8 @@ Throttling may occur when sending. Avoid throttling by using a
 How long is email saved?
 ------------------------
 
-Email messages are saved for somewhere between three days and 1 week or more, sometimes less. No guarantees!
+Email messages that are sent to public domains ( ie `mailsac.com`) are retained
+for 4 days and have a max number of messages per inbox of 6 days.
 
 *Message storage* prevents emails from being recycled.
 

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -76,8 +76,8 @@ Absolutely!
 
 We love to hear from developers that use Mailsac - contact us anytime.
 
-
-If you expect to send more than a few messages per minute, you might get throttled.
+Throttling may occur when sending. Avoid throttling by using a
+`Custom Domain <https://mailsac.com/domains>`_
 
 
 How long is email saved?

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -59,8 +59,8 @@ Most often, the following happens:
 3. Fast recycling. Without enough message storage, your inbound emails may be
    deleted quickly.
 4. Throttling. Non-paying customers can be throttled for sending too much. We
-   are happy to lift this for paying customers. Usually, it is easiest for us to
-   lift it on your `Custom Domain <https://mailsac.com/domains>`_.
+   are happy to lift this for paying customers.
+   `Custom Domain <https://mailsac.com/domains>`_ are not throttled.
 
 The Mailsac Team is highly responsive to `forum <https://forum.mailsac.com>`_
 and support emails. Contact us and we will resolve your issue.

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -104,5 +104,6 @@ You must `create an account <https://mailsac.com/register>`_ to reply to
 emails. New accounts have 5 sending credits. Additional credits can be
 `purchased <https://mailsac.com/pricing>_`.
 
-Or, you can use `POP3 <https://mailsac.com/docs/fetch-messages-with-pop3>`_ to download
-messages on a private address or custom domain.
+You can use `POP3 <https://mailsac.com/docs/fetch-messages-with-pop3>`_ to
+download messages on a private address or custom domain. Responses can be sent
+from non-mailsac accounts you have configured your email client to use.

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -6,19 +6,27 @@ Frequently Asked Questions
 Where are my email attachments?
 -------------------------------
 
-For `private addresses, the Inbox App will allow you to download attachments <https://mailsac.com/app>`_. You can also `fetch private messages with POP3 <https://mailsac.com/docs/fetch-messages-with-pop3>`_ in your email client, such as Apple Mail or GMail.
+For `private addresses, the Inbox App will allow you to download attachments
+<https://mailsac.com/app>`_. You can also `fetch private messages with POP3
+<https://mailsac.com/docs/fetch-messages-with-pop3>`_ in your email client,
+such as Apple Mail or GMail.
 
-Disposable emails under public email addresses disallow downloading attachments - :ref:`you must download the entire message file, or fetch attachments programmatically using the API <doc_attachments>`.
+Disposable emails under public email addresses disallow downloading attachments
+- :ref:`you must download the entire message file, or fetch attachments
+programmatically using the API <doc_attachments>`.
 
-For private addresses, using the `Unified Inbox App <https://mailsac.com/app>`_, attachment files are downloadable.
+For private addresses, when using the `Unified Inbox App
+<https://mailsac.com/app>`_, attachment files are downloadable.
 
-Attachments cannot be hosted publicly for download because attachments often contain viruses and spam.
+Attachments cannot be hosted publicly for download because attachments often
+contain viruses and spam.
 
 Why would I use Mailsac?
 ------------------------
 Any time you need a temporary email address, just make one `up@mailsac.com`.
 
-If you need to test your email system, send it to mailsac.com - even for a custom domain.
+If you need to test your email system, send it to mailsac.com - even for a
+custom domain.
 
 Other uses:
 
@@ -39,21 +47,23 @@ Why weren't my messages received?
 
 There are many reasons messages may not be received or displayed by Mailsac.
 
-The :ref:`doc_missingmail` page provides detailed explanations about why messages are not received.
+The :ref:`doc_missingmail` page provides detailed explanations about why
+messages are not received.
 
 Most often, the following happens:
 
-1. The sender blocks traffic to disposable email providers like Mailsac. This is
-   common with email signups or email verifications. People running websites do
-   not want a bunch of spam accounts.
+1. The sender blocks traffic to disposable email providers like Mailsac. This
+   is common with email signups or email verifications. People running websites
+   do not want a bunch of spam accounts.
 2. Large message size. Mailsac only supports messages up to about 2 MB.
-3. Fast recycling. Without enough message storage, your inbound emails may be deleted quickly.
+3. Fast recycling. Without enough message storage, your inbound emails may be
+   deleted quickly.
 4. Throttling. Non-paying customers can be throttled for sending too much. We
    are happy to lift this for paying customers. Usually, it is easiest for us to
    lift it on your `Custom Domain <https://mailsac.com/domains>`_.
 
-The Mailsac Team is highly responsive to `forum <https://forum.mailsac.com>`_ and support emails.
-Contact us and we will resolve your issue.
+The Mailsac Team is highly responsive to `forum <https://forum.mailsac.com>`_
+and support emails. Contact us and we will resolve your issue.
 
 .. tip::
   https://forum.mailsac.com

--- a/about/faq.rst
+++ b/about/faq.rst
@@ -30,14 +30,14 @@ custom domain.
 
 Other uses:
 
-* if you need an email address, but do not want to receive spam in your personal inbox
-* use it for sign ups on web sites that force you to login
+* avoid spam by keeping your real email address private
+* create an account on a website without disclosing your real email address
 * give it out to strangers
-* use it to collaborate for projects
+* use it as a shared email address
 * send mail to Mailsac for QA testing purposes
 * use it when you (legally) want to receive email without disclosing your identity
-* it is perfect if you want an email address or multiple addresses and do not want to sign up for them
-* comment on blogs without creating an account
+* send to an email address or multiple email addresses without needing to
+  create them
 * as a developer, to test that your application is sending email
 
 .. _faq-messages-not-received:


### PR DESCRIPTION
- Limit line length to 80 characters
- Update "Other Uses" section for clarity and brevity
- Use specific numbers when describing message retention
- Use specific numbers when describing sending limits on new accounts
- Clarify throttling on non-paying domains
- Describe how pop3 can be used with an email client to send email.