### PR TITLE
Sendgrid Information

### DIFF
--- a/help/missing_mail.rst
+++ b/help/missing_mail.rst
@@ -78,6 +78,16 @@ SendGrid
 Messages sent through SendGrid are often queued and may not be sent
 immediately.
 
+Sending from a `sendgrid.net` address may be impacted by :ref:`throttling <doc_smtp_throttling>`.
+Many Mailsac customers use SendGrid. Until `Sender Authentication <https://www.twilio.com/docs/glossary/sender-authentication>`_
+is configured within SendGrid, emails will be sent from the `sendgrid.net` domain.
+Sending from `sendgrid.net` email address can cause delays in delivery because of the
+quantity of mail sent from `sendgrid.net` to `mailsac.com`.
+Email sent to a :ref:`Private Address <doc_private_addresses>` or a
+:ref:`Custom Domain <doc_custom_domains>` are throttled at a :ref:`higher threshold <doc_smtp_throttling>`.
+In order to ensure timely delivery it is recommended to configure sender authentication
+in SendGrid and use a private address or custom domain at Mailsac.
+
 Mandrill
 ^^^^^^^^
 Messages sent through Mandrall are often `queued <https://mandrill.zendesk.com/hc/en-us/articles/205582717-Why-does-a-delivered-message-say-queued->`_


### PR DESCRIPTION
Make customers aware that sending with a "from" address in the sendgrid.net domain is likely to be impacted by throttling. This is because there are many mailsac.com customers using a sendgrid.net "from" address