### PR TITLE
Fix broken build on RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   builder: html
+   configuration: conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: requirements.txt

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ for testing purposes.
    `source venv/bin/activate`
 
 4. Install sphinx
-   `pip3 install Sphinx sphinx_rtd_theme sphinx-tabs`
+   `pip3 install -r requirements.txt`
 
 5. Run build script
    `make html`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 # This file instructs readthedocs to include these extensions in the build.
-https://github.com/djungelorm/sphinx-tabs/releases/download/v1.1.13/sphinx-tabs-1.1.13.tar.gz
+https://github.com/executablebooks/sphinx-tabs/archive/refs/tags/v3.2.0.tar.gz
+Sphinx==4.3.0
+sphinx-rtd-theme==1.0.0


### PR DESCRIPTION
- Fixes broken build related to [RTD changes](https://blog.readthedocs.com/build-errors-docutils-0-18/)
- Updates installation instructions
- Updates sphinx-tabs packages to current version to support more recent versions of python and sphinx