### PR TITLE
Add deprecation warning for outbound SMTP sending

### DIFF
--- a/api_examples/getting_started/getting_started.rst
+++ b/api_examples/getting_started/getting_started.rst
@@ -127,9 +127,7 @@ retrieve different parsed representations of the SMTP body.
 Sending Mail
 -------------
 
-.. important:: Sending messages requires the
-   `purchase <https://mailsac.com/pricing>`_ of outgoing message credits,
-   unless you are sending interally, within a custom domain hosted by Mailsac.
+.. warning:: Sending outbound SMTP email has been deprecated.
 
 To send an email from `user1@mailsac.com` we will use the
 :code:`/api/outgoing-messages` `endpoint

--- a/help/dns_verification/dns_verification.rst
+++ b/help/dns_verification/dns_verification.rst
@@ -76,6 +76,9 @@ correctly because it corresponds to the value in the table above.
 DKIM Record Verification
 ------------------------
 
+.. note:: Sending outbound SMTP email has been deprecated. DKIM records
+   will not will not be validated by mailsac in the future.
+
 DKIM Records are unique per domain. The value of the required DKIM record can
 be found in the Dashboard_ under Domains_, then click "Manage" and choose the
 "DNS Setup" tab.
@@ -101,6 +104,9 @@ the Dashboard_ under Domains_.
 
 SPF Record Verification
 -----------------------
+
+.. note:: Sending outbound SMTP email has been deprecated. SPF records
+   will not will not be validated by mailsac in the future.
 
 SPF Records are the same for all Private and Public Domains hosted by Mailsac.
 The Host will be unique per domain.

--- a/services/custom_domains/custom_domains.rst
+++ b/services/custom_domains/custom_domains.rst
@@ -217,6 +217,8 @@ Configure Custom Domain for Receiving Mail
 Configure Custom Domain for Sending Mail
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. warning:: Sending outbound SMTP email has been deprecated.
+
 #. Create a TXT record for DKIM (DomainKeys Identified Mail) with
    the hostname and value found on the DNS Setup page under the
    `Custom Domains <dash_custom_domains_>`_ page.

--- a/services/sending_mail/sending_mail.rst
+++ b/services/sending_mail/sending_mail.rst
@@ -8,6 +8,8 @@
 Sending Email
 =============
 
+.. warning:: Sending outbound SMTP email has been deprecated.
+
 Email can be sent via the following methods:
 
 - `Web Form`_


### PR DESCRIPTION
Adds deprecation warning where outbound SMTP sending is documented.
Adds notes to SPF and DKIM record setup / verification regarding the deprecation of outbound SMTP sending.

## sending_mail.rst

![Screen Shot 2022-04-20 at 7 12 07 AM](https://user-images.githubusercontent.com/5890769/164250165-ea5a8955-eaa1-4582-8be6-54533b061022.png)

## getting_started.rst

![Screen Shot 2022-04-20 at 7 13 17 AM](https://user-images.githubusercontent.com/5890769/164250974-690f31cd-f1e2-4ddd-ae49-f4b94f619355.png)


## dns_verification.rst

![Screen Shot 2022-04-20 at 7 13 58 AM](https://user-images.githubusercontent.com/5890769/164250572-259ca318-35c7-4690-b870-72bfba6503ba.png)

## custom_domains.rst
![Screen Shot 2022-04-20 at 7 14 43 AM](https://user-images.githubusercontent.com/5890769/164250779-44fc9125-d006-421e-8b79-0bbf7dbe7189.png)

