### PR TITLE
Rename private to enhanced addresses

### DIFF
--- a/about/faq.rst
+++ b/about/faq.rst
@@ -14,7 +14,7 @@ Where are my email attachments?
 Email attachments are not viewable for public addresses from the Website.
 Attachments must be downloaded using `REST API`_.
 
-Attachments on emails sent to :ref:`Private Addresses <doc_private_addresses>`
+Attachments on emails sent to :ref:`Enhanced Addresses <doc_private_addresses>`
 can be viewed in the `Unified Inbox`_ or in an email client using
 :ref:`POP3 <sec_reading_mail_pop3>`.
 
@@ -89,7 +89,7 @@ for 4 days and have a max number of 6 messages per inbox.
 *Message storage* prevents emails from being recycled.
 
 1. If you star a message, it will not be recycled until you unstar it.
-2. Private addresses will not be recycled, up to your storage limit.
+2. Messages in enhanced addresses will not be recycled, up to your storage limit.
 3. Messages on custom domains will not be recycled, up to your storage limit.
 
 Can other people see messages that I starred?
@@ -105,7 +105,7 @@ emails. New accounts have 5 sending credits. Additional credits can be
 `purchased <https://mailsac.com/pricing>_`.
 
 You can use `POP3 <https://mailsac.com/docs/fetch-messages-with-pop3>`_ to
-download messages on a private address or custom domain. Responses can be sent
+download messages on enhanced addresses or custom domains. Responses can be sent
 from non-mailsac accounts you have configured your email client to use.
 
 When does Ops/Operations/API Call Usage Reset?

--- a/about/privacy_policy.rst
+++ b/about/privacy_policy.rst
@@ -23,7 +23,7 @@ internet services that support the mailsac.com website).
 2. Email
 --------
 This site provides public (non-private) email, and public or private email testing services. Email inboxes that are not purchased (AKA private) are public and have no privacy expectation. Email inboxes and custom domains which are marked "public" by the user also have
-no expectation of privacy. Private addresses which are "released" or "deleted" or
+no expectation of privacy. Enhanced addresses which are "released" or "deleted" or
 for which the account loses good standing (such as due to a past-due subscription), may become non-private again.
 
 Consider this warning carefully when you opt to receive email on this website and give out addresses

--- a/about/terms_of_service.rst
+++ b/about/terms_of_service.rst
@@ -122,7 +122,7 @@ a. Public and Private Email
    email testing services. Email inboxes that are not purchased (aka private)
    are public and have no expectation of privacy.
 
-   Private addresses will not be accessible publicly and access to messages
+   Enhanced addresses will not be accessible publicly and access to messages
    will be provided only to those with:
 
       i. a validated username and password, which grants a temporary access

--- a/help/missing_mail.rst
+++ b/help/missing_mail.rst
@@ -29,7 +29,7 @@ received it could be because of:
 
 .. note::
   If you have a Mailsac subscription you should be sending to
-  :ref:`private addresses <doc_private_addresses>` or a
+  :ref:`enhanced addresses <doc_private_addresses>` or a
   :ref:`verified custom domain <doc_custom_domains>`. Mail sent to public
   addresses in the mailsac.com domain or a BYOD that has not been verified is
   subject to stricter throttling.
@@ -82,10 +82,10 @@ Many Mailsac customers use SendGrid. Until `Sender Authentication <https://www.t
 is configured within SendGrid, emails will be sent from the `sendgrid.net` domain.
 Sending from `sendgrid.net` email address can cause delays in delivery because of the
 quantity of mail sent from `sendgrid.net` to `mailsac.com`.
-Email sent to a :ref:`Private Address <doc_private_addresses>` or a
+Email sent to an :ref:`Enhanced Address <doc_private_addresses>` or a
 :ref:`Custom Domain <doc_custom_domains>` are throttled at a :ref:`higher threshold <doc_smtp_throttling>`.
 In order to ensure timely delivery it is recommended to configure sender authentication
-in SendGrid and use a private address or custom domain at Mailsac.
+in SendGrid and use an enhanced address or custom domain at Mailsac.
 
 Mandrill
 ^^^^^^^^

--- a/help/subscriptions/faq.rst
+++ b/help/subscriptions/faq.rst
@@ -35,7 +35,7 @@ renew.
 What happens if I cancel my subscription?
 -----------------------------------------
 
-Any custom domains, private addresses, and other paid features will be removed.
+Any custom domains, enhanced addresses, and other paid features will be removed.
 Cancelling before the end of the term will result in all paid features being removed
 immediately. The :ref:`operations (Ops) per month <doc_api_calls>` will immediately
 revert to the free tier limits.

--- a/help/throttling.rst
+++ b/help/throttling.rst
@@ -4,11 +4,11 @@
 Email Throttling
 ================
 
-Messages sent to custom domains and private addresses, held by customers
+Messages sent to custom domains and enhanced addresses, held by customers
 on a paid plan, are throttled differently than messages sent to public
 addresses in the mailsac.com domain.
 
-Throttling of messages on custom domains and private addresses will
+Throttling of messages on custom domains and enhanced addresses will
 likely be completely unnoticed by customers, with the exception of
 customers who are sending messages at the rate of thousands per minute.
 
@@ -23,13 +23,13 @@ throttling. This includes public @mailsac.com addresses and domains
 that have been configured to deliver mail to Mailsac, but are :ref:`not
 verified <doc_custom_domains>`.
 
-To increase the throttling threshold a :ref:`Private Address <doc_private_addresses>`
+To increase the throttling threshold an :ref:`Enhanced Address <doc_private_addresses>`
 or :ref:`Verified Custom Domain <doc_custom_domains>` should be be used.
 
-Throttling on Private Addresses or Custom Domains
+Throttling on Enhanced Addresses or Custom Domains
 -------------------------------------------------
 
-Most customers sending to :ref:`Private Addresses <doc_private_addresses>`
+Most customers sending to :ref:`Enhanced Addresses <doc_private_addresses>`
 or a :ref:`Verified Custom Domain <doc_custom_domains>` will never
 experience throttling.
 

--- a/services/api_calls/api_calls.rst
+++ b/services/api_calls/api_calls.rst
@@ -27,7 +27,7 @@ The following actions count as one Op:
 - API call to the `REST API`_
 - Using the "Unblock links and images", "Download", and "View Original" buttons
   to view an email.
-- Inbound message to a :ref:`private address <doc_private_addresses>`
+- Inbound message to an :ref:`enhanced address <doc_private_addresses>`
 - Inbound message to a :ref:`custom domain <doc_custom_domains>`
 - Publish message to a :ref:`WebSocket <doc_websocket>`
 - Publish message to :ref:`Webhook <doc_webhook_setup>`

--- a/services/attachments.rst
+++ b/services/attachments.rst
@@ -11,7 +11,7 @@ Getting Attachments as Files
 There are several ways to download attachments when authenticated to the Mailsac service
 
 1. By clicking the Download button on any public message, you can open it locally in an email client and view the attachements.
-2. For private addresses, attachments can be downloaded in a web browser using the `Unified Inbox app <https://mailsac.com/app>`_.
+2. For enhanced addresses, attachments can be downloaded in a web browser using the `Unified Inbox app <https://mailsac.com/app>`_.
 3. Attachments can be downloaded using the MD5 hash of the attachment,
    `using the common-attachments API <https://mailsac.com/docs/api#tag/Email-Message-Attachments/paths/~1addresses~1{email}~1messages~1{messageId}~1attachments~1{attachmentIdentifier}/get>`_.
 4. Attachments can be parsed out of the `raw` message using the `API <https://mailsac.com/docs/api#tag/Email-Messages-API/paths/~1raw~1{email}~1{messageId}/get>`_.

--- a/services/email_capture/email_capture.rst
+++ b/services/email_capture/email_capture.rst
@@ -31,9 +31,9 @@ SMTP configuration with these settings.
 
  Some SMTP libraries or clients may not support the use of a username that is
  different from the :code:`From` address. In that case, the :code:`From` address
- will need to be added as a :ref:`Private Address <doc_private_addresses>` or be
+ will need to be added as an :ref:`Enhanced Address <doc_private_addresses>` or be
  an address in a :ref:`Custom Domain <doc_custom_domains>`. The
- Private address or address in a Custom Domain can then be used with the Mailsac
+ enhanced address or address in a Custom Domain can then be used with the Mailsac
  API Key as authentication to the Capture service.
 
 .. tabs::

--- a/services/forwarding/forwarding.rst
+++ b/services/forwarding/forwarding.rst
@@ -8,7 +8,7 @@ Email Forwarding Overview
 =========================
 
 Forwarding, or routing, allows email to be sent on to a further email address
-or service (Webhook, WebSocket, Slack Webhook). Private addresses and custom
+or service (Webhook, WebSocket, Slack Webhook). Enhanced addresses and custom
 domains can be configured for email forwarding. Forwarding is not available on
 disposable email addresss.
 
@@ -19,7 +19,7 @@ Catch-All Domain Forwarding Addresses
 
 A Catch-All email address can receive all the mail for
 a custom domain, and optionally forward it to another address or service (
-Webhook, WebSocket, or Slack Webhook). A Catch-All address is a private address
+Webhook, WebSocket, or Slack Webhook). A Catch-All address is an enhanced address
 in the format `*@example.com`.
 
 A Catch-All email address can be configured by selecting `Manage Domains`_ from
@@ -69,13 +69,13 @@ it.
 Forward to Another Mailsac Address
 ----------------------------------
 
-Any private address, in the *@mailsac.com* domain or private domain can be
-forwarded to another private address. This allows you to consolidate many email
+Any enhanced address, in the *@mailsac.com* domain or private domain can be
+forwarded to another enhanced address. This allows you to consolidate many email
 addresses into a single inbox.
 
-Forwarding to another private address can be configured by selecting
+Forwarding to another enhanced address can be configured by selecting
 `Manage Email Addresses`_ from the Dashboard_. Select the *Settings* button
-next to the email address to manage, then choose the private address to forward
+next to the email address to manage, then choose the enhanced address to forward
 to from the *Forward to Another Email Address* dropdown and select *Save
 Settings*
 
@@ -92,11 +92,11 @@ main@mailsac.com, you could setup the following scheme:
 Forward to Slack
 ----------------
 
-Emails sent to a private address or Catch-All can be forwarded
+Emails sent to a enhanced address or Catch-All can be forwarded
 :ref:`to a Slack Channel <doc_slack_webhook>`.
 
-Slack forwarding requires a private address to be configured, but this can be
-a custom domain with a Catch-All private address (included with a verified
+Slack forwarding requires an enhanced address to be configured, but this can be
+a custom domain with a Catch-All enhanced address (included with a verified
 custom domain).
 
 Forwarding to Slack can be configured by selecting `Manage Email Addresses`_
@@ -109,7 +109,7 @@ Step-by-Step instructions are :ref:`provided <doc_slack_webhook>`.
 Forward to Webhook
 ------------------
 
-Private addresses and Catch-All addresses can have their mail forwarded to a
+Enhanced addresses and Catch-All addresses can have their mail forwarded to a
 webhook. :ref:`Configuration <doc_webhook_setup>` of the webhook only requires
 a destination URL.
 
@@ -123,7 +123,7 @@ Settings*.
 WebSocket Forwarding
 --------------------
 
-Private addresses and Catch-All addresses can have their mail forwarded to a
+Enhanced addresses and Catch-All addresses can have their mail forwarded to a
 WebSocket. A WebSocket uses a single persistent connection to notify a WebSocket
 client as soon as a message arrives. The `WebSocket Test Page
 <https://sock.mailsac.com>`_ demonstrates a WebSocket.

--- a/services/message_storage/message_storage.rst
+++ b/services/message_storage/message_storage.rst
@@ -26,11 +26,11 @@ storage.
 When are Messages Recycled?
 ---------------------------
 
-The oldest messages in a :ref:`Custom Domain <doc_custom_domains>` and
-:ref:`Private Address <doc_private_addresses>` are recycled once the
+The oldest messages in :ref:`Custom Domains <doc_custom_domains>` and
+:ref:`Enhanced Addresses <doc_private_addresses>` are recycled once the
 storage limit is reached.
 
-Messages sent to non-private addresses and unverified domains are kept for
+Messages sent to non-private (non-enhanced) addresses and unverified domains are kept for
 a maximum of 4 days, though messages may be recycled earlier to ensure
 capacity for customers on a paid subscription. There is a limit of 6
 messages per inbox.
@@ -115,7 +115,7 @@ Additional code examples are available in the
       .. figure:: delete_message_unified_inbox.gif
 
          Delete using the `Unified Inbox`_ (requires
-         :ref:`Private Address <doc_private_addresses>`)
+         :ref:`Enhanced Address <doc_private_addresses>`)
 
    .. tab:: curl
 
@@ -139,7 +139,7 @@ Additional code examples are available in the
 Purge Inbox
 -----------
 
-The Purge Inbox features requires the Inbox to be a :ref:`Private Address
+The Purge Inbox features requires the Inbox to be an :ref:`Enhanced Address
 <doc_private_addresses>`.
 
 Additional code examples are available in the

--- a/services/private_addresses/private_addresses.rst
+++ b/services/private_addresses/private_addresses.rst
@@ -15,15 +15,15 @@ Private Email Addresses have additional features:
 - `Read / Send Mail using a mail client <https://mailsac.com/docs/fetch-messages-with-pop3>`_
 - `Purge inbox <https://blog.mailsac.com/2020/07/21/easy-purging-of-inboxes/>`_
 
-Reserve a Private Address
+Reserve an Enhanced Address
 -------------------------
 
 .. include:: ./reserve_private_address.rst
 
-Private Addresses In a Custom Domain
+Enhanced Addresses In a Custom Domain
 ------------------------------------
 
-Private Addresses can be used in :ref:`Custom Domains <doc_custom_domains>`.
+Enhanced Addresses can be used in :ref:`Custom Domains <doc_custom_domains>`.
 This allows an address within a :ref:`Custom Domain <doc_custom_domains>` to
 have the features of a
-:ref:`Private Email Address <doc_private_addresses>`.
+:ref:`Enhanced Email Address <doc_private_addresses>`.

--- a/services/private_addresses/reserve_private_address.rst
+++ b/services/private_addresses/reserve_private_address.rst
@@ -5,22 +5,22 @@
 
       .. figure:: reserve_private_address.gif
 
-         Reserve private address
+         Reserve Enhanced Address
 
    .. tab:: curl
 
        .. literalinclude:: curl_reserve_private_address.txt
           :language: bash
-          :caption: Reserve Private Address
+          :caption: Reserve Enhanced Address
 
-   .. tab:: Node.js Javascript 
+   .. tab:: Node.js Javascript
 
        .. literalinclude:: nodejs_reserve_private_address.js
           :language: javascript
-          :caption: Reserve Private Address
+          :caption: Reserve Enhanced Address
 
    .. tab:: Python
 
        .. literalinclude:: python_reserve_private_address.py
           :language: python
-          :caption: Reserve Private Address
+          :caption: Reserve Enhanced Address

--- a/services/reading_mail/reading_mail.rst
+++ b/services/reading_mail/reading_mail.rst
@@ -79,7 +79,7 @@ Unified Inbox
 -------------
 
 The `Unified Inbox`_ provides a way to view the mail of all
-:ref:`private addresses <doc_private_addresses>` for the logged in Mailsac account.
+:ref:`enhanced addresses <doc_private_addresses>` for the logged in Mailsac account.
 
 .. figure:: unified_inbox_view.png
 
@@ -109,9 +109,9 @@ Reading via POP3 allows email clients to read email.
 **Authentication**
 
 POP3 uses a username and password for authentication. The API key or SMTP Key
-for your account can be used to read from any of your :ref:`private addresses
-<doc_private_addresses>`. Alternatively, you can use a per private address SMTP
-password. The per private address SMTP password can be set through using the
+for your account can be used to read from any of your :ref:`enhanced addresses
+<doc_private_addresses>`. Alternatively, you can use a per enhanced address SMTP
+password. The per enhanced address SMTP password can be set through using the
 Dashboard_ -> *Manage Email Addresses* -> Select the
 *POP/SMTP* button next to the email address -> Select *Set New Password*
 
@@ -143,8 +143,8 @@ etc) using these POP3 settings:
 Viewing Email Attachments
 -------------------------
 
-For :ref:`private addresses <doc_private_addresses>`, the `Unified Inbox`_
-allows downloading of attachments. Email fetched from private addresses using
+For :ref:`enhanced addresses <doc_private_addresses>`, the `Unified Inbox`_
+allows downloading of attachments. Email fetched from enhanced addresses using
 :ref:`POP3 from an email client <sec_reading_mail_pop3>`
 such as Apple Mail or GMail, will include attachments.
 

--- a/services/slack_webhook/slack_webhook.rst
+++ b/services/slack_webhook/slack_webhook.rst
@@ -4,7 +4,7 @@ Slack Integration
 =================
 
 Mailsac integrates email seamlessly with Slack, using Slack webhooks. It works even
-on a free Slack workspace. Using a Mailsac private email address, you can configure
+on a free Slack workspace. Using a Mailsac enhanced email address, you can configure
 forwarding messages directly to a Slack channel.
 
 Forwarding email to Slack is available on
@@ -67,7 +67,7 @@ portal <https://api.slack.com/apps/new>`_.
 Configure Mailsac Email Address to Forward Messages to Slack
 ------------------------------------------------------------
 
-**1.** To configure Slack integration, select settings for your private email address from the Mailsac
+**1.** To configure Slack integration, select settings for your enhanced email address from the Mailsac
 `console <https://mailsac.com/addresses>`_.
 
 .. figure:: slack_select_email.png
@@ -80,7 +80,7 @@ Configure Mailsac Email Address to Forward Messages to Slack
     :align: center
     :width: 400px
 
-**3.** Send a test email to your Mailsac private address. It should post to the Slack channel.
+**3.** Send a test email to your Mailsac enhanced address. It should post to the Slack channel.
 
 If messages are not being forwarded, you can check `Recent Mail Activity Log <https://mailsac.com/usage>`_ under the Usage
 section of the Mailsac dashboard.
@@ -88,7 +88,7 @@ section of the Mailsac dashboard.
 Test Slack Webhook
 ------------------
 
-Send an email to the :ref:`Private Address <doc_private_addresses>`, that was
+Send an email to the :ref:`Enhanced Address <doc_private_addresses>`, that was
 :ref:`configured for Slack Forwarding
 <sec_configure_address_for_slack_forwarding>`.
 

--- a/services/webhook/webhook.rst
+++ b/services/webhook/webhook.rst
@@ -25,20 +25,20 @@ Configure Webhook
 
        .. literalinclude:: webhook_setting.sh
           :language: bash
-          :caption: Configure webhook forwarding on private address using curl
+          :caption: Configure webhook forwarding on an enhanced address using curl
 
    .. tab:: Node.js Javascript
 
        .. literalinclude:: webhook_setting.js
           :language: javascript
-          :caption: Configure webhook forwarding on a private address using
+          :caption: Configure webhook forwarding on an enhanced address using
                     Node.js. requires :code:`npm install superagent`
 
    .. tab:: Python
 
        .. literalinclude:: webhook_setting.py
           :language: python
-          :caption: Configure webhook forwarding on a private address using
+          :caption: Configure webhook forwarding on an enhanced address using
                     Python.
 
 Webhook Sample JSON

--- a/services/websocket/websocket.rst
+++ b/services/websocket/websocket.rst
@@ -12,25 +12,25 @@ and reduces latency from when the email arrives and your application responds to
 Want to see it in action? The `WebSocket Test Page <https://sock.mailsac.com/>`_ allows
 you to show how it works with no programming involved.
 
-.. tip:: You will need an :ref:`API key <sec_api_key_management>` and a
-         :ref:`private address <doc_private_addresses>` or custom domain.
+.. tip:: You will need an :ref:`API key <sec_api_key_management>` and an
+         :ref:`enhanced address <doc_private_addresses>` or custom domain.
 
 
 .. _sec_private_address_for_websocket:
 
-Configure Private Address for WebSocket
+Configure an Enhanced Address for WebSocket
 ----------------------------------------
 
-To use the Websocket feature a private email is required. Private addresses can
+To use the Websocket feature an enhanced email is required. Enhanced addresses can
 be purchased `individually <https://mailsac.com/pricing>`_ as part of a `API Developer Subscription
 <https://mailsac.com/subscription>`_.
 
-Option 1: Reserve Private Address via API
+Option 1: Reserve an Enhanced Address via API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The REST API is the easiest way to reserve a private address.
+The REST API is the easiest way to reserve an enhanced address.
 
-A simple HTTP POST will do. Make sure you have private address credits already, from a paid plan or addon purchase.
+A simple HTTP POST will do. Make sure you have an enhanced address credits already, from a paid plan or addon purchase.
 
 user1@mailsac.com in the example should be replaced with the email address you wish to reserve. If you use a custom domain,
 different than mailsac.com, you must have the domain configured with DNS records to delivery mail to Mailsac.
@@ -39,7 +39,7 @@ different than mailsac.com, you must have the domain configured with DNS records
 
      curl -X POST -H "Mailsac-Key: YOUR_API_KEY_HERE" https://mailsac.com/api/addresses/user1@mailsac.com
 
-Next, configure the private address for web socket publishing:
+Next, configure the an enhanced address for web socket publishing:
 
 .. code-block:: bash
 
@@ -47,7 +47,7 @@ Next, configure the private address for web socket publishing:
 
 
 
-Option 2: Reserve Private Address in the Dashboard
+Option 2: Reserve an Enhanced Address in the Dashboard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. `Sign in <https://mailsac.com/login>`_ to your Mailsac account.


### PR DESCRIPTION
The mailsac webapp uses the term "Enhanced Addresses". This updates the documentation to be consistent.